### PR TITLE
ci: trigger status check on 'synchronize' for lint-pr-title

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -5,6 +5,7 @@ on:
     types:
       - opened
       - edited
+      - synchronize
 
 jobs:
   conventional-commit:


### PR DESCRIPTION
Since Github invalidates status checks upon the "synchronize" events, the status check will be pending forever before this PR is merged.