### PR TITLE
docs(readme): include help message in 'How It Works'

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,36 @@
 
 ## Motivation
 
-TL;DR When I press `PrtScn`, I want the screenshot to be automatically stored to a specified directory.
+TL;DR When I press `PrtScn`, I want the screenshot to be automatically stored to the specified directory.
 
 When I'm watching movies on Windows and feeling like taking a screenshot, I prefer `Windows+PrtScn` over `PrtScn` because the former can automatically save the screenshot for me, while regarding the latter, I have to manually paste the screenshot somewhere else before taking the next screenshot. However, if I press `Windows+PrtScn` when I'm watching Netflix, the pressing of `Windows` makes Netflix show the playback control options, which will appear in the screenshot, and I don't want that. As a result, I have to resort to `PrtScn`, but I also want to preserve the convenience provided by `Windows+PrtScn` at the same time, so this project is born.
 
 ## How It Works
 
-1. Start this program. Run `clip-saver --help` to learn more about what it can do.
+1. Start this program.
 1. Start watching the movie.
 1. Every time an image is copied to the system clipboard, a corresponding image file is created in the specified directory.
 1. Finish watching the movie.
 1. Terminate the program.
 1. Enjoy your screenshots!
+
+For more details:
+
+```sh
+$ ./clip-saver --help
+Usage: clip-saver [--dir <dir>] [--conf <conf-path>]
+
+Automatically save images from the system clipboard to the specified directory.
+
+If there is no screenshot (i.e., filenames conforming to the screenshot format) at the moment, the screenshots will be saved in <dir> as 1.png, 2.png, and so on; if there are some existing screenshots with the latest one being 5.png, the screenshots will be saved in <dir> as 6.png, 7.png, and so on.
+
+  -conf string
+        optional; the path to the configuration file. For more details regarding the format of it and a working example, please check https://github.com/davidhsingyuchen/clip-saver/blob/main/clip-saver.yml. If this flag is not present, <dir>/clip-saver.yaml is used. If the file does not exist, movie mode instead of TV series mode is assumed.
+  -dir string
+        optional; the directory to save the clipped images. If it does not exist yet, this program will attempt to create it. If it is not specified, the current working directory will be used.
+  -version
+        print version information
+```
 
 ## Use It
 

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ const (
 )
 
 func main() {
+	// Whenever the help message changes, please update the "How It Works" section in README.md.
 	flag.Usage = func() {
 		fmt.Fprintf(flag.CommandLine.Output(), "Usage: clip-saver [--dir <dir>] [--conf <conf-path>] \n\n"+
 			"Automatically save images from the system clipboard to the specified directory.\n\n"+


### PR DESCRIPTION
There is a risk that the help message in `README.md` becomes outdated, but that is still better than nothing in `README.md`.